### PR TITLE
Migration to sound null-safety

### DIFF
--- a/lib/src/ai.dart
+++ b/lib/src/ai.dart
@@ -30,17 +30,17 @@ class AI {
 
   final AIFormatType _type;
 
-  final int _fixLength;
+  final int? _fixLength;
   final String _regExpString;
   final String _description;
 
   const AI({
-    String code,
-    String dataTitle,
-    AIFormatType type,
-    int fixLength,
-    String regExpString,
-    String description,
+    required String code,
+    required String dataTitle,
+    required AIFormatType type,
+    int? fixLength,
+    required String regExpString,
+    required String description,
   })  : _fixLength = fixLength,
         _code = code,
         _dataTitle = dataTitle,
@@ -70,13 +70,12 @@ class AI {
   RegExp get regExp => RegExp(_regExpString);
 
   /// Number of places for decimal element (for other is 0)
-  int get numberOfDecimalPlaces =>
-      (code.length == 4) ? int.parse(code[3], radix: 10) : 0;
+  int get numberOfDecimalPlaces => (code.length == 4) ? int.parse(code[3], radix: 10) : 0;
 
   /// Length for AI with fixed length (for other is 0)
   int get fixLength {
-    if (type == AIFormatType.FIXED_LENGTH) return _fixLength;
-    if (type == AIFormatType.FIXED_LENGTH_MEASURE) return _fixLength;
+    if (type == AIFormatType.FIXED_LENGTH) return _fixLength ?? 0;
+    if (type == AIFormatType.FIXED_LENGTH_MEASURE) return _fixLength ?? 0;
     if (type == AIFormatType.DATE) return _DATE_FIX_LENGTH;
     return 0;
   }
@@ -117,6 +116,7 @@ class AI {
     '11': const AI(
       code: '11',
       type: AIFormatType.DATE,
+      fixLength: AI._DATE_FIX_LENGTH,
       dataTitle: 'PROD DATE',
       regExpString: r'^11(\d{6})$',
       description: 'Production date (YYMMDD)',
@@ -124,6 +124,7 @@ class AI {
     '12': const AI(
       code: '12',
       type: AIFormatType.DATE,
+      fixLength: AI._DATE_FIX_LENGTH,
       dataTitle: 'DUE DATE',
       regExpString: r'^12(\d{6})$',
       description: 'Due date (YYMMDD)',
@@ -131,6 +132,7 @@ class AI {
     '13': const AI(
       code: '13',
       type: AIFormatType.DATE,
+      fixLength: AI._DATE_FIX_LENGTH,
       dataTitle: 'PACK DATE',
       regExpString: r'^13(\d{6})$',
       description: 'Packaging date (YYMMDD)',
@@ -138,6 +140,7 @@ class AI {
     '15': const AI(
       code: '15',
       type: AIFormatType.DATE,
+      fixLength: AI._DATE_FIX_LENGTH,
       dataTitle: 'BEST BEFORE or BEST BY',
       regExpString: r'^15(\d{6})$',
       description: 'Best before date (YYMMDD)',
@@ -145,6 +148,7 @@ class AI {
     '16': const AI(
       code: '16',
       type: AIFormatType.DATE,
+      fixLength: AI._DATE_FIX_LENGTH,
       dataTitle: 'SELL BY',
       regExpString: r'^16(\d{6})$',
       description: 'Sell by date (YYMMDD)',
@@ -152,6 +156,7 @@ class AI {
     '17': const AI(
       code: '17',
       type: AIFormatType.DATE,
+      fixLength: AI._DATE_FIX_LENGTH,
       dataTitle: 'USE BY OR EXPIRY',
       description: 'Expiration date (YYMMDD)',
       regExpString: r'^17(\d{6})$',
@@ -190,8 +195,7 @@ class AI {
       type: AIFormatType.VARIABLE_LENGTH,
       dataTitle: 'ADDITIONAL ID',
       regExpString: '^240($_ALLOW_CHAR{0,30})\$',
-      description:
-          'Additional product identification assigned by the manufacturer',
+      description: 'Additional product identification assigned by the manufacturer',
     ),
     '241': const AI(
       code: '241',
@@ -302,40 +306,35 @@ class AI {
         code: '3110',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (m)',
-        description:
-            'Length or first dimension, metres (variable measure trade item)',
+        description: 'Length or first dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3110(\d{6})$'),
     '3111': const AI(
         code: '3111',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (m)',
-        description:
-            'Length or first dimension, metres (variable measure trade item)',
+        description: 'Length or first dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3111(\d{6})$'),
     '3112': const AI(
         code: '3112',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (m)',
-        description:
-            'Length or first dimension, metres (variable measure trade item)',
+        description: 'Length or first dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3112(\d{6})$'),
     '3113': const AI(
         code: '3113',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (m)',
-        description:
-            'Length or first dimension, metres (variable measure trade item)',
+        description: 'Length or first dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3113(\d{6})$'),
     '3114': const AI(
         code: '3114',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (m)',
-        description:
-            'Length or first dimension, metres (variable measure trade item)',
+        description: 'Length or first dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3114(\d{6})$'),
     '3115': const AI(
@@ -349,96 +348,84 @@ class AI {
         code: '3110',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (m)',
-        description:
-            'Width, diameter, or second dimension, metres (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3110(\d{6})$'),
     '3121': const AI(
         code: '3121',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (m)',
-        description:
-            'Width, diameter, or second dimension, metres (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3121(\d{6})$'),
     '3122': const AI(
         code: '3122',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (m)',
-        description:
-            'Width, diameter, or second dimension, metres (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3122(\d{6})$'),
     '3123': const AI(
         code: '3123',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (m)',
-        description:
-            'Width, diameter, or second dimension, metres (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3123(\d{6})$'),
     '3124': const AI(
         code: '3124',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (m)',
-        description:
-            'Width, diameter, or second dimension, metres (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3124(\d{6})$'),
     '3125': const AI(
         code: '3125',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (m)',
-        description:
-            'Width, diameter, or second dimension, metres (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3125(\d{6})$'),
     '3130': const AI(
         code: '3130',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (m)',
-        description:
-            'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3130(\d{6})$'),
     '3131': const AI(
         code: '3131',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (m)',
-        description:
-            'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3131(\d{6})$'),
     '3132': const AI(
         code: '3132',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (m)',
-        description:
-            'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3132(\d{6})$'),
     '3133': const AI(
         code: '3133',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (m)',
-        description:
-            'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3133(\d{6})$'),
     '3134': const AI(
         code: '3134',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (m)',
-        description:
-            'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3134(\d{6})$'),
     '3135': const AI(
         code: '3135',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (m)',
-        description:
-            'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, metres (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3135(\d{6})$'),
     '3140': const AI(
@@ -613,462 +600,404 @@ class AI {
         code: '3210',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (in)',
-        description:
-            'Length or first dimension, inches (variable measure trade item)',
+        description: 'Length or first dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3210(\d{6})$'),
     '3211': const AI(
         code: '3211',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (in)',
-        description:
-            'Length or first dimension, inches (variable measure trade item)',
+        description: 'Length or first dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3211(\d{6})$'),
     '3212': const AI(
         code: '3210',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (in)',
-        description:
-            'Length or first dimension, inches (variable measure trade item)',
+        description: 'Length or first dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3211(\d{6})$'),
     '3213': const AI(
         code: '3213',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (in)',
-        description:
-            'Length or first dimension, inches (variable measure trade item)',
+        description: 'Length or first dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3213(\d{6})$'),
     '3214': const AI(
         code: '3214',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (in)',
-        description:
-            'Length or first dimension, inches (variable measure trade item)',
+        description: 'Length or first dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3214(\d{6})$'),
     '3215': const AI(
         code: '3214',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (in)',
-        description:
-            'Length or first dimension, inches (variable measure trade item)',
+        description: 'Length or first dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3214(\d{6})$'),
     '3220': const AI(
         code: '3220',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (ft)',
-        description:
-            'Length or first dimension, feet (variable measure trade item)',
+        description: 'Length or first dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3220(\d{6})$'),
     '3221': const AI(
         code: '3221',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (ft)',
-        description:
-            'Length or first dimension, feet (variable measure trade item)',
+        description: 'Length or first dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3221(\d{6})$'),
     '3222': const AI(
         code: '3222',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (ft)',
-        description:
-            'Length or first dimension, feet (variable measure trade item)',
+        description: 'Length or first dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3222(\d{6})$'),
     '3223': const AI(
         code: '3223',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (ft)',
-        description:
-            'Length or first dimension, feet (variable measure trade item)',
+        description: 'Length or first dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3223(\d{6})$'),
     '3224': const AI(
         code: '3224',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (ft)',
-        description:
-            'Length or first dimension, feet (variable measure trade item)',
+        description: 'Length or first dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3224(\d{6})$'),
     '3225': const AI(
         code: '3225',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (ft)',
-        description:
-            'Length or first dimension, feet (variable measure trade item)',
+        description: 'Length or first dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3225(\d{6})$'),
     '3230': const AI(
         code: '3230',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (yd)',
-        description:
-            'Length or first dimension, yards (variable measure trade item)',
+        description: 'Length or first dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3230(\d{6})$'),
     '3231': const AI(
         code: '3231',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (yd)',
-        description:
-            'Length or first dimension, yards (variable measure trade item)',
+        description: 'Length or first dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3231(\d{6})$'),
     '3232': const AI(
         code: '3232',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (yd)',
-        description:
-            'Length or first dimension, yards (variable measure trade item)',
+        description: 'Length or first dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3232(\d{6})$'),
     '3233': const AI(
         code: '3233',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (yd)',
-        description:
-            'Length or first dimension, yards (variable measure trade item)',
+        description: 'Length or first dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3233(\d{6})$'),
     '3234': const AI(
         code: '3234',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (yd)',
-        description:
-            'Length or first dimension, yards (variable measure trade item)',
+        description: 'Length or first dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3234(\d{6})$'),
     '3235': const AI(
         code: '3230',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'LENGTH (yd)',
-        description:
-            'Length or first dimension, yards (variable measure trade item)',
+        description: 'Length or first dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3235(\d{6})$'),
     '3240': const AI(
         code: '3240',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (in)',
-        description:
-            'Width, diameter, or second dimension, inches (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3240(\d{6})$'),
     '3241': const AI(
         code: '3241',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (in)',
-        description:
-            'Width, diameter, or second dimension, inches (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3241(\d{6})$'),
     '3242': const AI(
         code: '3242',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (in)',
-        description:
-            'Width, diameter, or second dimension, inches (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3242(\d{6})$'),
     '3243': const AI(
         code: '3243',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (in)',
-        description:
-            'Width, diameter, or second dimension, inches (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3243(\d{6})$'),
     '3244': const AI(
         code: '3244',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (in)',
-        description:
-            'Width, diameter, or second dimension, inches (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3244(\d{6})$'),
     '3245': const AI(
         code: '3245',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (in)',
-        description:
-            'Width, diameter, or second dimension, inches (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3245(\d{6})$'),
     '3250': const AI(
         code: '3250',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (ft)',
-        description:
-            'Width, diameter, or second dimension, feet (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3250(\d{6})$'),
     '3251': const AI(
         code: '3251',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (ft)',
-        description:
-            'Width, diameter, or second dimension, feet (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3251(\d{6})$'),
     '3252': const AI(
         code: '3252',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (ft)',
-        description:
-            'Width, diameter, or second dimension, feet (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3252(\d{6})$'),
     '3253': const AI(
         code: '3253',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (ft)',
-        description:
-            'Width, diameter, or second dimension, feet (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3253(\d{6})$'),
     '3254': const AI(
         code: '3254',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (ft)',
-        description:
-            'Width, diameter, or second dimension, feet (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3254(\d{6})$'),
     '3255': const AI(
         code: '3255',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (ft)',
-        description:
-            'Width, diameter, or second dimension, feet (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3255(\d{6})$'),
     '3260': const AI(
         code: '3260',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (yd)',
-        description:
-            'Width, diameter, or second dimension, yards (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3260(\d{6})$'),
     '3261': const AI(
         code: '3261',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (yd)',
-        description:
-            'Width, diameter, or second dimension, yards (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3261(\d{6})$'),
     '3262': const AI(
         code: '3262',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (yd)',
-        description:
-            'Width, diameter, or second dimension, yards (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3262(\d{6})$'),
     '3263': const AI(
         code: '3263',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (yd)',
-        description:
-            'Width, diameter, or second dimension, yards (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3263(\d{6})$'),
     '3264': const AI(
         code: '3264',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (yd)',
-        description:
-            'Width, diameter, or second dimension, yards (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3264(\d{6})$'),
     '3265': const AI(
         code: '3265',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'WIDTH (yd)',
-        description:
-            'Width, diameter, or second dimension, yards (variable measure trade item)',
+        description: 'Width, diameter, or second dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3265(\d{6})$'),
     '3270': const AI(
         code: '3270',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (in)',
-        description:
-            'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3270(\d{6})$'),
     '3271': const AI(
         code: '3271',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (in)',
-        description:
-            'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3271(\d{6})$'),
     '3272': const AI(
         code: '3272',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (in)',
-        description:
-            'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3272(\d{6})$'),
     '3273': const AI(
         code: '3273',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (in)',
-        description:
-            'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3273(\d{6})$'),
     '3274': const AI(
         code: '3274',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (in)',
-        description:
-            'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3274(\d{6})$'),
     '3275': const AI(
         code: '3275',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (in)',
-        description:
-            'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, inches (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3275(\d{6})$'),
     '3280': const AI(
         code: '3280',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (ft)',
-        description:
-            'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3280(\d{6})$'),
     '3281': const AI(
         code: '3281',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (ft)',
-        description:
-            'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3281(\d{6})$'),
     '3282': const AI(
         code: '3282',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (ft)',
-        description:
-            'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3282(\d{6})$'),
     '3283': const AI(
         code: '3283',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (ft)',
-        description:
-            'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3283(\d{6})$'),
     '3284': const AI(
         code: '3284',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (ft)',
-        description:
-            'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3284(\d{6})$'),
     '3285': const AI(
         code: '3285',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (ft)',
-        description:
-            'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, feet (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3285(\d{6})$'),
     '3290': const AI(
         code: '3290',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (yd)',
-        description:
-            'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3290(\d{6})$'),
     '3291': const AI(
         code: '3291',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (yd)',
-        description:
-            'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3291(\d{6})$'),
     '3292': const AI(
         code: '3292',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (yd)',
-        description:
-            'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3292(\d{6})$'),
     '3293': const AI(
         code: '3293',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (yd)',
-        description:
-            'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3293(\d{6})$'),
     '3294': const AI(
         code: '3294',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (yd)',
-        description:
-            'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3294(\d{6})$'),
     '3295': const AI(
         code: '3295',
         type: AIFormatType.FIXED_LENGTH_MEASURE,
         dataTitle: 'HEIGHT (yd)',
-        description:
-            'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
+        description: 'Depth, thickness, height, or third dimension, yards (variable measure trade item)',
         fixLength: 6,
         regExpString: r'^3295(\d{6})$'),
     '37': const AI(
         code: '37',
         type: AIFormatType.VARIABLE_LENGTH,
         dataTitle: 'COUNT',
-        description:
-        'Count of trade items or trade item pieces contained in a logistic unit',
+        description: 'Count of trade items or trade item pieces contained in a logistic unit',
         fixLength: 8,
         regExpString: r'^37(\d{0,8})$'),
     '3922': const AI(
         code: '3922',
         type: AIFormatType.VARIABLE_LENGTH_MEASURE,
         dataTitle: 'PRICE',
-        description:
-            'Applicable amount payable, single monetary area (variable measure trade item)',
+        description: 'Applicable amount payable, single monetary area (variable measure trade item)',
         regExpString: r'^3922(\d{0,15})$'),
     '3932': const AI(
         code: '3932',
         type: AIFormatType.VARIABLE_LENGTH_WITH_ISO_NUMBERS,
         dataTitle: 'PRICE',
-        description:
-            'Applicable amount payable with ISO currency code (variable measure trade item)',
+        description: 'Applicable amount payable with ISO currency code (variable measure trade item)',
         regExpString: r'^3932(\d{3})(\d{0,15})$'),
     '3933': const AI(
         code: '3933',
         type: AIFormatType.VARIABLE_LENGTH_WITH_ISO_NUMBERS,
         dataTitle: 'PRICE',
-        description:
-            'Applicable amount payable with ISO currency code (variable measure trade item)',
+        description: 'Applicable amount payable with ISO currency code (variable measure trade item)',
         regExpString: r'^3933(\d{3})(\d{0,15})$'),
     '421': const AI(
         code: '421',

--- a/lib/src/code.dart
+++ b/lib/src/code.dart
@@ -17,9 +17,9 @@ class Code {
   final String fnc1;
 
   const Code({
-    this.type,
-    this.codeTitle,
-    this.fnc1,
+    required this.type,
+    required this.codeTitle,
+    required this.fnc1,
   });
 
   @override

--- a/lib/src/code_parser.dart
+++ b/lib/src/code_parser.dart
@@ -5,8 +5,8 @@ class CodeWithRest {
   final String rest;
 
   const CodeWithRest({
-    this.code,
-    this.rest,
+    required this.code,
+    required this.rest,
   });
 }
 
@@ -17,9 +17,7 @@ abstract class GS1CodeParser {
 class GS1PrefixCodeParser implements GS1CodeParser {
   @override
   CodeWithRest call(String data) {
-    var code = Code.CODES.values.firstWhere(
-        (element) => data.startsWith(element.fnc1),
-        orElse: () => Code.UNDEFINED_CODE);
+    var code = Code.CODES.values.firstWhere((element) => data.startsWith(element.fnc1), orElse: () => Code.UNDEFINED_CODE);
 
     return CodeWithRest(
       rest: data.substring(code.fnc1.length),

--- a/lib/src/element_parser.dart
+++ b/lib/src/element_parser.dart
@@ -10,8 +10,8 @@ class ParsedElementWithRest {
   final String rest;
 
   const ParsedElementWithRest({
-    this.element,
-    this.rest,
+    required this.element,
+    required this.rest,
   });
 }
 
@@ -24,8 +24,7 @@ abstract class GS1ElementParser {
 
   double parseFloatingPoint(String numberPart, int numberOfDecimals) {
     final offset = numberPart.length - numberOfDecimals;
-    final numberPartFloat =
-        numberPart.substring(0, offset) + '.' + numberPart.substring(offset);
+    final numberPartFloat = numberPart.substring(0, offset) + '.' + numberPart.substring(offset);
     return double.parse(numberPartFloat);
   }
 
@@ -40,14 +39,12 @@ abstract class GS1ElementParser {
 
 class GS1DateParser extends GS1ElementParser {
   @override
-  ParsedElementWithRest call(
-      String data, AI ai, GS1BarcodeParserConfig config) {
+  ParsedElementWithRest call(String data, AI ai, GS1BarcodeParserConfig config) {
     final offset = ai.code.length + ai.fixLength;
     final elementStr = data.substring(0, min(offset, data.length));
 
     if (!verify(elementStr, ai)) {
-      throw GS1ParseException(
-          message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
+      throw GS1ParseException(message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
     }
 
     final elementDate = elementStr.substring(ai.code.length);
@@ -72,15 +69,13 @@ class GS1DateParser extends GS1ElementParser {
 
 class GS1ElementFixLengthParser extends GS1ElementParser {
   @override
-  ParsedElementWithRest call(
-      String data, AI ai, GS1BarcodeParserConfig config) {
+  ParsedElementWithRest call(String data, AI ai, GS1BarcodeParserConfig config) {
     final offset = ai.code.length + ai.fixLength;
 
     final elementStr = data.substring(0, min(offset, data.length));
 
     if (!verify(elementStr, ai)) {
-      throw GS1ParseException(
-          message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
+      throw GS1ParseException(message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
     }
     final elementValue = elementStr.substring(ai.code.length);
 
@@ -97,23 +92,19 @@ class GS1ElementFixLengthParser extends GS1ElementParser {
 
 class GS1ElementFixLengthMeasureParser extends GS1ElementParser {
   @override
-  ParsedElementWithRest call(
-      String data, AI ai, GS1BarcodeParserConfig config) {
+  ParsedElementWithRest call(String data, AI ai, GS1BarcodeParserConfig config) {
     final offset = ai.code.length + ai.fixLength;
 
     final elementStr = data.substring(0, min(offset, data.length));
 
     if (!verify(elementStr, ai)) {
-      throw GS1ParseException(
-          message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
+      throw GS1ParseException(message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
     }
 
     final elementValue = elementStr.substring(ai.code.length);
 
-    final element = GS1ParsedElement<double>(
-        rawData: elementValue,
-        aiCode: ai.code,
-        data: parseFloatingPoint(elementValue, ai.numberOfDecimalPlaces));
+    final element =
+        GS1ParsedElement<double>(rawData: elementValue, aiCode: ai.code, data: parseFloatingPoint(elementValue, ai.numberOfDecimalPlaces));
     final rest = getRest(data, offset, config);
 
     return ParsedElementWithRest(element: element, rest: rest);
@@ -122,15 +113,13 @@ class GS1ElementFixLengthMeasureParser extends GS1ElementParser {
 
 class GS1VariableLengthParser extends GS1ElementParser {
   @override
-  ParsedElementWithRest call(
-      String data, AI ai, GS1BarcodeParserConfig config) {
+  ParsedElementWithRest call(String data, AI ai, GS1BarcodeParserConfig config) {
     final posOfGS = data.indexOf(config.groupSeparator);
     final offset = posOfGS == -1 ? data.length : posOfGS;
     final elementStr = data.substring(0, offset);
 
     if (!verify(elementStr, ai)) {
-      throw GS1ParseException(
-          message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
+      throw GS1ParseException(message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
     }
 
     final elementValue = elementStr.substring(ai.code.length);
@@ -151,38 +140,32 @@ class GS1VariableLengthParser extends GS1ElementParser {
 
 class GS1VariableLengthMeasureParser extends GS1ElementParser {
   @override
-  ParsedElementWithRest call(
-      String data, AI ai, GS1BarcodeParserConfig config) {
+  ParsedElementWithRest call(String data, AI ai, GS1BarcodeParserConfig config) {
     final posOfGS = data.indexOf(config.groupSeparator);
     final offset = posOfGS == -1 ? data.length : posOfGS;
     final elementStr = data.substring(0, offset);
 
     if (!verify(elementStr, ai)) {
-      throw GS1ParseException(
-          message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
+      throw GS1ParseException(message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
     }
 
     final numberPart = data.substring(ai.code.length, offset);
     final rest = getRest(data, offset, config);
-    final element = GS1ParsedElement<double>(
-        rawData: numberPart,
-        aiCode: ai.code,
-        data: parseFloatingPoint(numberPart, ai.numberOfDecimalPlaces));
+    final element =
+        GS1ParsedElement<double>(rawData: numberPart, aiCode: ai.code, data: parseFloatingPoint(numberPart, ai.numberOfDecimalPlaces));
     return ParsedElementWithRest(element: element, rest: rest);
   }
 }
 
 class GS1VariableLengthWithISONumbersParser extends GS1ElementParser {
   @override
-  ParsedElementWithRest call(
-      String data, AI ai, GS1BarcodeParserConfig config) {
+  ParsedElementWithRest call(String data, AI ai, GS1BarcodeParserConfig config) {
     final posOfGS = data.indexOf(config.groupSeparator);
     final offset = posOfGS == -1 ? data.length : posOfGS;
     final elementStr = data.substring(0, offset);
 
     if (!verify(elementStr, ai)) {
-      throw GS1ParseException(
-          message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
+      throw GS1ParseException(message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
     }
 
     final numberPart = elementStr.substring(ai.code.length + 3);
@@ -201,15 +184,13 @@ class GS1VariableLengthWithISONumbersParser extends GS1ElementParser {
 
 class GS1VariableLengthWithISOCharsParser extends GS1ElementParser {
   @override
-  ParsedElementWithRest call(
-      String data, AI ai, GS1BarcodeParserConfig config) {
+  ParsedElementWithRest call(String data, AI ai, GS1BarcodeParserConfig config) {
     final posOfGS = data.indexOf(config.groupSeparator);
     final offset = posOfGS == -1 ? data.length : posOfGS;
     final elementStr = data.substring(0, offset);
 
     if (!verify(elementStr, ai)) {
-      throw GS1ParseException(
-          message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
+      throw GS1ParseException(message: 'Data format mismatch ${ai.regExp} for AI ${ai.code}');
     }
 
     final charPart = elementStr.substring(ai.code.length + 3);

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -1,20 +1,20 @@
 class GS1Exception implements Exception {
   final String message;
 
-  GS1Exception({this.message});
+  GS1Exception({required this.message});
 
   @override
   String toString() {
-    return message ?? super.toString();
+    return message;
   }
 }
 
 /// Bad data exception
 class GS1DataException extends GS1Exception {
-  GS1DataException({String message}) : super(message: message);
+  GS1DataException({required String message}) : super(message: message);
 }
 
 /// Parse exception
 class GS1ParseException extends GS1Exception {
-  GS1ParseException({String message}) : super(message: message);
+  GS1ParseException({required String message}) : super(message: message);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,342 +7,335 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "14.0.0"
+    version: "22.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.41.2"
+    version: "1.7.0"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.1.1"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.3.1"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.2"
+    version: "1.0.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "3.0.1"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.2"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.2"
+    version: "2.0.1"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.9"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.4"
+    version: "1.4.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.11.0"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "2.0.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.9"
+    version: "1.1.4"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9+2"
+    version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.4+1"
+    version: "1.0.1"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.6"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.7"
+    version: "1.17.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.18+1"
+    version: "0.4.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.11+4"
+    version: "0.3.28"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "7.1.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,9 +4,9 @@ version: 0.0.8
 homepage: https://github.com/mobui/gs1_barcode_parser
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
-  test: ^1.15.4
+  test: ^1.17.8
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gs1_barcode_parser
 description: The barcode parser is a library for handling the contents of GS1 barcodes.
-version: 0.0.8
+version: 1.0.0
 homepage: https://github.com/mobui/gs1_barcode_parser
 
 environment:

--- a/test/barcode_parser_test.dart
+++ b/test/barcode_parser_test.dart
@@ -2,11 +2,9 @@ import 'package:gs1_barcode_parser/gs1_barcode_parser.dart';
 import 'package:test/test.dart';
 
 main() {
-  final String barcode =
-      ']C101040123456789011715012910ABC1233932971471131030005253922471142127649716';
+  final String barcode = ']C101040123456789011715012910ABC1233932971471131030005253922471142127649716';
 
-  final String barcode2 =
-      '01040123456789011715012910ABC123393297147113103000525392247114212764971691';
+  final String barcode2 = '01040123456789011715012910ABC123393297147113103000525392247114212764971691';
 
   test('Instance object', () {
     final parser = GS1BarcodeParser.defaultParser();
@@ -19,9 +17,15 @@ main() {
     final parser = GS1BarcodeParser.defaultParser();
     final result = parser.parse(barcode);
     print(result);
-    expect(result.code.type, CodeType.GS1_128);
-    expect(result.hasAI('01'), true);
-    expect(result.getAIRawData('01'), '04012345678901');
+    test('codeType', () {
+      expect(result.code.type, CodeType.GS1_128);
+    });
+    test('hasAI', () {
+      expect(result.hasAI('01'), true);
+    });
+    test('getAIRawData', () {
+      expect(result.getAIRawData('01'), '04012345678901');
+    });
   });
 
   test('Parse raw barcode from scanner', () {

--- a/test/code_parser_test.dart
+++ b/test/code_parser_test.dart
@@ -13,29 +13,28 @@ main() {
   test('parse GS1 Data Matrix code', () {
     final codeWithRest = codeParser(gs1DataMatrix);
     expect(codeWithRest.code.type, equals(CodeType.DATAMATRIX));
-    expect(
-        codeWithRest.code.fnc1, equals(Code.CODES[CodeType.DATAMATRIX].fnc1));
+    expect(codeWithRest.code.fnc1, equals(Code.CODES[CodeType.DATAMATRIX]!.fnc1));
     expect(codeWithRest.rest, equals(gs1WithoutFNC1));
   });
 
   test('parse GS1 QR code', () {
     final codeWithRest = codeParser(gs1QRCode);
     expect(codeWithRest.code.type, equals(CodeType.QR_CODE));
-    expect(codeWithRest.code.fnc1, equals(Code.CODES[CodeType.QR_CODE].fnc1));
+    expect(codeWithRest.code.fnc1, equals(Code.CODES[CodeType.QR_CODE]!.fnc1));
     expect(codeWithRest.rest, equals(gs1WithoutFNC1));
   });
 
   test('parse GS1 Code-128 code', () {
     final codeWithRest = codeParser(gs1Code128);
     expect(codeWithRest.code.type, equals(CodeType.GS1_128));
-    expect(codeWithRest.code.fnc1, equals(Code.CODES[CodeType.GS1_128].fnc1));
+    expect(codeWithRest.code.fnc1, equals(Code.CODES[CodeType.GS1_128]!.fnc1));
     expect(codeWithRest.rest, equals(gs1WithoutFNC1));
   });
 
   test('parse GS1 EAN code', () {
     final codeWithRest = codeParser(gs1EAN);
     expect(codeWithRest.code.type, equals(CodeType.EAN));
-    expect(codeWithRest.code.fnc1, equals(Code.CODES[CodeType.EAN].fnc1));
+    expect(codeWithRest.code.fnc1, equals(Code.CODES[CodeType.EAN]!.fnc1));
     expect(codeWithRest.rest, equals(gs1WithoutFNC1));
   });
 

--- a/test/element_parser_test.dart
+++ b/test/element_parser_test.dart
@@ -14,8 +14,7 @@ main() {
     final fixLengthParser = GS1ElementFixLengthParser();
 
     test('Fixed length element successful parsed', () {
-      final elementWithRest =
-          fixLengthParser(gs1WithoutFNC1, AI.AIS['01'], config);
+      final elementWithRest = fixLengthParser(gs1WithoutFNC1, AI.AIS['01'] as AI, config);
       expect(elementWithRest.rest, equals('1719112510ABCD1234'));
       expect(elementWithRest.element.data, equals('03453120000011'));
       expect(elementWithRest.element.aiCode, equals('01'));
@@ -24,29 +23,23 @@ main() {
 
     test('Fixed length element failed parse short data', () {
       expect(
-          () => fixLengthParser(gs1WithoutFNC1Truncated, AI.AIS['01'], config),
-          throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^01(\d{14})$ flags= for AI 01')));
+          () => fixLengthParser(gs1WithoutFNC1Truncated, AI.AIS['01'] as AI, config),
+          throwsA(predicate(
+              (e) => e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^01(\d{14})$ flags= for AI 01')));
     });
 
     test('Fixed length element failed parse mismatched data an AI', () {
       expect(
-          () => fixLengthParser(gs1WithoutFNC1, AI.AIS['02'], config),
-          throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^02(\d{14})$ flags= for AI 02')));
+          () => fixLengthParser(gs1WithoutFNC1, AI.AIS['02'] as AI, config),
+          throwsA(predicate(
+              (e) => e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^02(\d{14})$ flags= for AI 02')));
     });
 
     test('Fixed length element failed parse with the wrong format', () {
       expect(
-          () => fixLengthParser(gs1WithoutUnformatted, AI.AIS['01'], config),
-          throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^01(\d{14})$ flags= for AI 01')));
+          () => fixLengthParser(gs1WithoutUnformatted, AI.AIS['01'] as AI, config),
+          throwsA(predicate(
+              (e) => e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^01(\d{14})$ flags= for AI 01')));
     });
   });
 
@@ -57,7 +50,7 @@ main() {
     final String gs1WithoutFNC1Truncated = '17150';
 
     test('Date element successful parsed', () {
-      final elementWithRest = dateParser(gs1WithoutFNC1, AI.AIS['17'], config);
+      final elementWithRest = dateParser(gs1WithoutFNC1, AI.AIS['17'] as AI, config);
       expect(elementWithRest.rest, equals('10ABC12339329714711'));
       expect(elementWithRest.element.data, equals(DateTime(2015, 1, 29)));
       expect(elementWithRest.element.rawData, equals('150129'));
@@ -66,29 +59,23 @@ main() {
 
     test('Date element failed parse short data', () {
       expect(
-          () => dateParser(gs1WithoutFNC1Truncated, AI.AIS['17'], config),
-          throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^17(\d{6})$ flags= for AI 17')));
+          () => dateParser(gs1WithoutFNC1Truncated, AI.AIS['17'] as AI, config),
+          throwsA(predicate(
+              (e) => e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^17(\d{6})$ flags= for AI 17')));
     });
 
     test('Fixed length element failed parse mismatched data an AI', () {
       expect(
-          () => dateParser(gs1WithoutFNC1, AI.AIS['16'], config),
-          throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^16(\d{6})$ flags= for AI 16')));
+          () => dateParser(gs1WithoutFNC1, AI.AIS['16'] as AI, config),
+          throwsA(predicate(
+              (e) => e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^16(\d{6})$ flags= for AI 16')));
     });
 
     test('Fixed length element failed parse with the wrong format', () {
       expect(
-          () => dateParser(gs1WithoutUnformatted, AI.AIS['17'], config),
-          throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^17(\d{6})$ flags= for AI 17')));
+          () => dateParser(gs1WithoutUnformatted, AI.AIS['17'] as AI, config),
+          throwsA(predicate(
+              (e) => e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^17(\d{6})$ flags= for AI 17')));
     });
   });
 
@@ -99,8 +86,7 @@ main() {
     final String gs1WithoutFNC1Truncated = '1039329714711';
 
     test('Variable length element successful parsed', () {
-      final elementWithRest =
-          variableLengthParser(gs1WithoutFNC1, AI.AIS['10'], config);
+      final elementWithRest = variableLengthParser(gs1WithoutFNC1, AI.AIS['10'] as AI, config);
       expect(elementWithRest.rest, equals('39329714711'));
       expect(elementWithRest.element.data, equals('ABC123'));
       expect(elementWithRest.element.rawData, equals('ABC123'));
@@ -108,8 +94,7 @@ main() {
     });
 
     test('Variable length empty element successful parsed', () {
-      final elementWithRest =
-          variableLengthParser(gs1WithoutFNC1Truncated, AI.AIS['10'], config);
+      final elementWithRest = variableLengthParser(gs1WithoutFNC1Truncated, AI.AIS['10'] as AI, config);
       expect(elementWithRest.rest, equals('39329714711'));
       expect(elementWithRest.element.data, equals(''));
       expect(elementWithRest.element.rawData, equals(''));
@@ -118,21 +103,18 @@ main() {
 
     test('Variable length  element failed parse mismatched data an AI', () {
       expect(
-          () => variableLengthParser(gs1WithoutFNC1, AI.AIS['21'], config),
+          () => variableLengthParser(gs1WithoutFNC1, AI.AIS['21'] as AI, config),
           throwsA(predicate((e) =>
               e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^21([!-"%-/0-9:-?A-Z_a-z]{0,20})$ flags= for AI 21')));
+              e.message == r'Data format mismatch RegExp: pattern=^21([!-"%-/0-9:-?A-Z_a-z]{0,20})$ flags= for AI 21')));
     });
 
     test('Variable length element failed parse with the wrong format', () {
       expect(
-          () =>
-              variableLengthParser(gs1WithoutUnformatted, AI.AIS['10'], config),
+          () => variableLengthParser(gs1WithoutUnformatted, AI.AIS['10'] as AI, config),
           throwsA(predicate((e) =>
               e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^10([!-"%-/0-9:-?A-Z_a-z]{0,20})$ flags= for AI 10')));
+              e.message == r'Data format mismatch RegExp: pattern=^10([!-"%-/0-9:-?A-Z_a-z]{0,20})$ flags= for AI 10')));
     });
   });
 
@@ -143,8 +125,7 @@ main() {
     final String gs1WithoutFNC1Truncated = '310300';
 
     test('Variable length element successful parsed', () {
-      final elementWithRest =
-          fixLengthMeasureParser(gs1WithoutFNC1, AI.AIS['3103'], config);
+      final elementWithRest = fixLengthMeasureParser(gs1WithoutFNC1, AI.AIS['3103'] as AI, config);
       expect(elementWithRest.rest, equals('3922471142127649716'));
       expect(elementWithRest.element.data, equals(0.525));
       expect(elementWithRest.element.rawData, equals('000525'));
@@ -153,47 +134,35 @@ main() {
 
     test('Fixed length measure  element failed parse short data', () {
       expect(
-          () => fixLengthMeasureParser(
-              gs1WithoutFNC1Truncated, AI.AIS['3103'], config),
-          throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^3103(\d{6})$ flags= for AI 3103')));
+          () => fixLengthMeasureParser(gs1WithoutFNC1Truncated, AI.AIS['3103'] as AI, config),
+          throwsA(predicate(
+              (e) => e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^3103(\d{6})$ flags= for AI 3103')));
     });
 
     test('Fixed length measure element failed parse mismatched data an AI', () {
       expect(
-          () => fixLengthMeasureParser(gs1WithoutFNC1, AI.AIS['3102'], config),
-          throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^3102(\d{6})$ flags= for AI 3102')));
+          () => fixLengthMeasureParser(gs1WithoutFNC1, AI.AIS['3102'] as AI, config),
+          throwsA(predicate(
+              (e) => e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^3102(\d{6})$ flags= for AI 3102')));
     });
 
     test('Fixed length measure element failed parse with the wrong format', () {
       expect(
-          () => fixLengthMeasureParser(
-              gs1WithoutUnformatted, AI.AIS['3103'], config),
-          throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^3103(\d{6})$ flags= for AI 3103')));
+          () => fixLengthMeasureParser(gs1WithoutUnformatted, AI.AIS['3103'] as AI, config),
+          throwsA(predicate(
+              (e) => e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^3103(\d{6})$ flags= for AI 3103')));
     });
   });
 
   group('Variable length with ISO number element', () {
-    final variableLengthWithISONumbersParser =
-        GS1VariableLengthWithISONumbersParser();
+    final variableLengthWithISONumbersParser = GS1VariableLengthWithISONumbersParser();
     final String gs1WithoutFNC1 = '3932971471131030005253922471142127649716';
-    final String gs1WithoutUnformatted =
-        '39329A147131030005253922471142127649716';
-    final String gs1WithoutUnformatted2 =
-        '393297147A131030005253922471142127649716';
+    final String gs1WithoutUnformatted = '39329A147131030005253922471142127649716';
+    final String gs1WithoutUnformatted2 = '393297147A131030005253922471142127649716';
     final String gs1WithoutFNC1Truncated = '393297';
 
     test('Variable length with ISO number element successful parsed', () {
-      final elementWithRest = variableLengthWithISONumbersParser(
-          gs1WithoutFNC1, AI.AIS['3932'], config);
+      final elementWithRest = variableLengthWithISONumbersParser(gs1WithoutFNC1, AI.AIS['3932'] as AI, config);
       expect(elementWithRest.rest, equals('31030005253922471142127649716'));
       expect(elementWithRest.element.data, equals(47.11));
       expect(elementWithRest.element.rawData, equals('9714711'));
@@ -203,64 +172,42 @@ main() {
 
     test('Variable length with ISO number element failed parse short data', () {
       expect(
-          () => variableLengthWithISONumbersParser(
-              gs1WithoutFNC1Truncated, AI.AIS['3932'], config),
+          () => variableLengthWithISONumbersParser(gs1WithoutFNC1Truncated, AI.AIS['3932'] as AI, config),
           throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^3932(\d{3})(\d{0,15})$ flags= for AI 3932')));
+              e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^3932(\d{3})(\d{0,15})$ flags= for AI 3932')));
     });
 
-    test(
-        'Variable length with ISO number element failed parse mismatched data an AI',
-        () {
+    test('Variable length with ISO number element failed parse mismatched data an AI', () {
       expect(
-          () => variableLengthWithISONumbersParser(
-              gs1WithoutFNC1, AI.AIS['3933'], config),
+          () => variableLengthWithISONumbersParser(gs1WithoutFNC1, AI.AIS['3933'] as AI, config),
           throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^3933(\d{3})(\d{0,15})$ flags= for AI 3933')));
+              e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^3933(\d{3})(\d{0,15})$ flags= for AI 3933')));
     });
 
-    test(
-        'Variable length with ISO number element failed parse with the wrong format',
-        () {
+    test('Variable length with ISO number element failed parse with the wrong format', () {
       expect(
-          () => variableLengthWithISONumbersParser(
-              gs1WithoutUnformatted, AI.AIS['3933'], config),
+          () => variableLengthWithISONumbersParser(gs1WithoutUnformatted, AI.AIS['3933'] as AI, config),
           throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^3933(\d{3})(\d{0,15})$ flags= for AI 3933')));
+              e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^3933(\d{3})(\d{0,15})$ flags= for AI 3933')));
     });
 
-    test(
-        'Variable length with ISO number element failed parse with the wrong format 2',
-        () {
+    test('Variable length with ISO number element failed parse with the wrong format 2', () {
       expect(
-          () => variableLengthWithISONumbersParser(
-              gs1WithoutUnformatted2, AI.AIS['3933'], config),
+          () => variableLengthWithISONumbersParser(gs1WithoutUnformatted2, AI.AIS['3933'] as AI, config),
           throwsA(predicate((e) =>
-              e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^3933(\d{3})(\d{0,15})$ flags= for AI 3933')));
+              e is GS1ParseException && e.message == r'Data format mismatch RegExp: pattern=^3933(\d{3})(\d{0,15})$ flags= for AI 3933')));
     });
   });
 
   group('Variable length with ISO chars element', () {
-    final variableLengthWithISOCharsParser =
-        GS1VariableLengthWithISOCharsParser();
+    final variableLengthWithISOCharsParser = GS1VariableLengthWithISOCharsParser();
     final String gs1WithoutFNC1 = '4212764971631030005253922471142127649716';
-    final String gs1WithoutUnformatted =
-        '4212A64971631030005253922471142127649716';
-    final String gs1WithoutUnformatted2 =
-        '421276497П631030005253922471142127649716';
+    final String gs1WithoutUnformatted = '4212A64971631030005253922471142127649716';
+    final String gs1WithoutUnformatted2 = '421276497П631030005253922471142127649716';
     final String gs1WithoutFNC1Truncated = '42127';
 
     test('Variable length with ISO chars element successful parsed', () {
-      final elementWithRest = variableLengthWithISOCharsParser(
-          gs1WithoutFNC1, AI.AIS['421'], config);
+      final elementWithRest = variableLengthWithISOCharsParser(gs1WithoutFNC1, AI.AIS['421'] as AI, config);
       expect(elementWithRest.rest, equals('31030005253922471142127649716'));
       expect(elementWithRest.element.data, equals('49716'));
       expect(elementWithRest.element.rawData, equals('27649716'));
@@ -270,48 +217,34 @@ main() {
 
     test('Variable length with ISO chars  element failed parse short data', () {
       expect(
-          () => variableLengthWithISOCharsParser(
-              gs1WithoutFNC1Truncated, AI.AIS['421'], config),
+          () => variableLengthWithISOCharsParser(gs1WithoutFNC1Truncated, AI.AIS['421'] as AI, config),
           throwsA(predicate((e) =>
               e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^421(\d{3})([!-"%-/0-9:-?A-Z_a-z]{0,9})$ flags= for AI 421')));
+              e.message == r'Data format mismatch RegExp: pattern=^421(\d{3})([!-"%-/0-9:-?A-Z_a-z]{0,9})$ flags= for AI 421')));
     });
 
-    test(
-        'Variable length with ISO chars  element failed parse mismatched data an AI',
-        () {
+    test('Variable length with ISO chars  element failed parse mismatched data an AI', () {
       expect(
-          () => variableLengthWithISOCharsParser(
-              gs1WithoutFNC1, AI.AIS['10'], config),
+          () => variableLengthWithISOCharsParser(gs1WithoutFNC1, AI.AIS['10'] as AI, config),
           throwsA(predicate((e) =>
               e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^10([!-"%-/0-9:-?A-Z_a-z]{0,20})$ flags= for AI 10')));
+              e.message == r'Data format mismatch RegExp: pattern=^10([!-"%-/0-9:-?A-Z_a-z]{0,20})$ flags= for AI 10')));
     });
 
-    test(
-        'Variable length with ISO chars  element failed parse with the wrong format',
-        () {
+    test('Variable length with ISO chars  element failed parse with the wrong format', () {
       expect(
-          () => variableLengthWithISOCharsParser(
-              gs1WithoutUnformatted, AI.AIS['421'], config),
+          () => variableLengthWithISOCharsParser(gs1WithoutUnformatted, AI.AIS['421'] as AI, config),
           throwsA(predicate((e) =>
               e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^421(\d{3})([!-"%-/0-9:-?A-Z_a-z]{0,9})$ flags= for AI 421')));
+              e.message == r'Data format mismatch RegExp: pattern=^421(\d{3})([!-"%-/0-9:-?A-Z_a-z]{0,9})$ flags= for AI 421')));
     });
 
-    test(
-        'Variable length with ISO chars  element failed parse with the wrong format 2',
-        () {
+    test('Variable length with ISO chars  element failed parse with the wrong format 2', () {
       expect(
-          () => variableLengthWithISOCharsParser(
-              gs1WithoutUnformatted2, AI.AIS['421'], config),
+          () => variableLengthWithISOCharsParser(gs1WithoutUnformatted2, AI.AIS['421'] as AI, config),
           throwsA(predicate((e) =>
               e is GS1ParseException &&
-              e.message ==
-                  r'Data format mismatch RegExp: pattern=^421(\d{3})([!-"%-/0-9:-?A-Z_a-z]{0,9})$ flags= for AI 421')));
+              e.message == r'Data format mismatch RegExp: pattern=^421(\d{3})([!-"%-/0-9:-?A-Z_a-z]{0,9})$ flags= for AI 421')));
     });
   });
 }


### PR DESCRIPTION
First of all, thanks for open source for this library!

This PR migrates the library to be sound null-safety.
The one thing that was broken for some reason is 2 of 3 tests in barcode_parser_test.dart – for some reason, a parser cannot be found. If you have an idea how to fix that, I would appreciate this. It's strange, because I didn't change anything related to this.